### PR TITLE
Ignore empty saved files

### DIFF
--- a/lib/benchmark/ips/job.rb
+++ b/lib/benchmark/ips/job.rb
@@ -187,10 +187,10 @@ module Benchmark
       end
 
       def load_held_results
-        return unless @held_path && File.exist?(@held_path)
+        return unless @held_path && File.exist?(@held_path) && !(contents = IO.read(@held_path)).empty?
         require "json"
         @held_results = {}
-        JSON.load(IO.read(@held_path)).each do |result|
+        JSON.load(contents).each do |result|
           @held_results[result['item']] = result
           create_report(result['item'], result['measured_us'], result['iter'],
                         create_stats(result['samples']), result['cycles'])


### PR DESCRIPTION
The current code fails if a save file is specified and already exists on disk but is empty. That makes it harder to script using temp files, since you'd generally want to pre-create the temp file.

While it's possible to workaround this by writing `"[]"` to the file ahead of time, you essentially need to read the code to realize that's why you're getting a "NoMethodError each on nil" exception, so it seems better to just handle this up front.